### PR TITLE
.NET 8.0 RC1 - Upgrade

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           dotnet tool install dotnet-reportgenerator-globaltool
           dotnet tool install dotnet-coverage
       - name: Run the unit tests with code coverage
-        run: dotnet coverage collect dotnet test --filter TodoApiTests --output ${{ github.workspace }}/Tests/Coverage --output-format cobertura
+        run: dotnet coverage collect dotnet test --filter TodoApiTests --output ${{ github.workspace }}/Tests/Coverage/Coverage.cobertura.xml --output-format cobertura
       - name: Generate Report
         run: |
           dotnet reportgenerator -reports:${{ github.workspace }}/Tests/Coverage.cobertura.xml -targetdir:"${{ github.workspace }}/Tests/coveragereport" -reporttypes:"MarkdownSummary;Html" -assemblyfilters:+MinimalApi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           dotnet tool install dotnet-reportgenerator-globaltool
           dotnet tool install dotnet-coverage
       - name: Run the unit tests with code coverage
-        run: dotnet coverage collect dotnet test --filter TodoApiTests --output ${{ github.workspace }}/Tests/Coverage/Coverage.cobertura.xml --output-format cobertura
+        run: dotnet coverage collect dotnet test --filter TodoApiTests --output ${{ github.workspace }}/Tests/Coverage.cobertura.xml --output-format cobertura
       - name: Generate Report
         run: |
           dotnet reportgenerator -reports:${{ github.workspace }}/Tests/Coverage.cobertura.xml -targetdir:"${{ github.workspace }}/Tests/coveragereport" -reporttypes:"MarkdownSummary;Html" -assemblyfilters:+MinimalApi
@@ -62,7 +62,6 @@ jobs:
         run: |
           echo "USER1_TOKEN=$(dotnet user-jwts create --claim Username=user1 --claim Email=user1@example.com --name user1 --output token)" >> $GITHUB_ENV
           echo "USER2_TOKEN=$(dotnet user-jwts create --claim Username=user2 --claim Email=user2@example.com --name user2 --output token)" >> $GITHUB_ENV
-
       - name: Running Integration Tests
         run: dotnet test --filter TodoApiIntegrationTests
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Set up .NET Core
         uses: actions/setup-dotnet@v3.0.3
         with:
-          dotnet-version: "7.0.x"
+          dotnet-version: "8.0.x"
+          dotnet-quality: "preview"
 
       - name: Build with dotnet
         run: dotnet build --configuration Release

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ ASP.NET Core 7.0 - Minimal API Example - Todo API implementation using ASP.NET C
 
 ## Features
 
+## September 22, 2023
+* Upgraded to .NET 8 RC1 - [More details](https://devblogs.microsoft.com/dotnet/announcing-dotnet-8-rc1/?WT.mc_id=DT-MVP-5002040)
+
 ## November 29, 2022
 * Implemented Rate Limiting support for Web API in .NET 7 - [Learn more about this feature](https://learn.microsoft.com/aspnet/core/performance/rate-limit?view=aspnetcore-7.0&WT.mc_id=DT-MVP-5002040)
 * Removed GraphQL support.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ASP.NET Core 7.0 - Minimal API Example.
+# ASP.NET Core 8.0 - Minimal API Example.
 
-ASP.NET Core 7.0 - Minimal API Example - Todo API implementation using ASP.NET Core Minimal API, Entity Framework Core, Token authentication, Versioning, Unit Testing, Integration Testing and Open API.
+ASP.NET Core 8.0 - Minimal API Example - Todo API implementation using ASP.NET Core Minimal API, Entity Framework Core, Token authentication, Versioning, Unit Testing, Integration Testing and Open API.
 
 [![Build and Deployment](https://github.com/anuraj/MinimalApi/actions/workflows/main.yml/badge.svg)](https://github.com/anuraj/MinimalApi/actions/workflows/main.yml)
 
@@ -8,6 +8,7 @@ ASP.NET Core 7.0 - Minimal API Example - Todo API implementation using ASP.NET C
 
 ## September 22, 2023
 * Upgraded to .NET 8 RC1 - [More details](https://devblogs.microsoft.com/dotnet/announcing-dotnet-8-rc1/?WT.mc_id=DT-MVP-5002040)
+* No other .NET 8 features implemented.
 
 ## November 29, 2022
 * Implemented Rate Limiting support for Web API in .NET 7 - [Learn more about this feature](https://learn.microsoft.com/aspnet/core/performance/rate-limit?view=aspnetcore-7.0&WT.mc_id=DT-MVP-5002040)

--- a/Source/MinimalApi.csproj
+++ b/Source/MinimalApi.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net8.0</TargetFramework>
 		<Nullable>enable</Nullable>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<UserSecretsId>c863d8a7-6953-45aa-baa6-3b932debfdd0</UserSecretsId>
@@ -13,18 +13,17 @@
 	<ItemGroup>
 		<PackageReference Include="Asp.Versioning.Http" Version="6.3.1" />
 		<PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
-		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="7.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.0">
+		<PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0-rc.1.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Authorization" Version="8.0.0-rc.1.*" />
+		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.0-rc.1.*" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0-rc.1.*">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
-		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="7.0.0" />
-		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0" />
-		<PackageReference Include="Microsoft.NET.Build.Containers" Version="0.2.7" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-rc.1.*" />
+		<PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.0-rc.1.*" />
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.0-rc.1.*" />
+		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0-rc.1.*" />
 		<PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
 	</ItemGroup>
 	<ItemGroup>

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -91,7 +91,7 @@ builder.Services.AddSwaggerGen(setup =>
 {
     setup.SwaggerDoc("v1", new OpenApiInfo()
     {
-        Description = "ASP.NET Core 7.0 - Minimal API Example - Todo API implementation using ASP.NET Core Minimal API," +
+        Description = "ASP.NET Core 8.0 - Minimal API Example - Todo API implementation using ASP.NET Core Minimal API," +
             "Entity Framework Core, Token authentication, Versioning, Unit Testing and Open API.",
         Title = "Todo Api",
         Version = "v1",

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -165,7 +165,7 @@ app.MapGroup("/todoitems")
         stopwatch.Stop();
         var elapsed = stopwatch.ElapsedMilliseconds;
         var response = efiContext.HttpContext.Response;
-        response.Headers.Add("X-Response-Time", $"{elapsed} milliseconds");
+        response.Headers.TryAdd("X-Response-Time", $"{elapsed} milliseconds");
         return result;
     });
 

--- a/Tests/MinimalApi.Tests.csproj
+++ b/Tests/MinimalApi.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -14,10 +14,10 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.2.2" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.0-rc.1.*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="7.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0-rc.1.*" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Changes related to .NET 8.0 RC1

1. In Project files, target framework changed to net8.0
2. Updated all `Microsoft.AspNetCore.*` package references to `8.0.0-rc.1.*`
3. Updated all `Microsoft.Extensions.*` package references to `8.0.0-rc.1.*.`
4. Fixed one warning - `Headers.Add` changed to `Headers.TryAdd`